### PR TITLE
feat: Implement Admin Panel with Membership CRUD

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,9 @@ import Login from "./pages/Login";
 import Admin from "./pages/Admin";
 import NotFound from "./pages/NotFound";
 import ProtectedRoute from "./components/layout/ProtectedRoute";
+import AdminLayout from "./components/layout/AdminLayout";
+import AdminDashboard from "./pages/AdminDashboard";
+import AdminMembershipPage from "./pages/AdminMembershipPage";
 
 const queryClient = new QueryClient();
 
@@ -27,6 +30,7 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <Routes>
+            {/* Public user-facing routes */}
             <Route path="/" element={<Layout />}>
               <Route index element={<Home />} />
               <Route path="about" element={<About />} />
@@ -35,11 +39,19 @@ const App = () => (
               <Route path="gallery" element={<Gallery />} />
               <Route path="contact" element={<Contact />} />
             </Route>
+
+            {/* Standalone auth routes */}
             <Route path="join-now" element={<JoinNow />} />
             <Route path="login" element={<Login />} />
+
+            {/* Protected admin routes with a separate layout */}
             <Route element={<ProtectedRoute requiredRole="admin" />}>
-              <Route path="admin" element={<Admin />} />
+              <Route path="/admin" element={<AdminLayout />}>
+                <Route index element={<AdminDashboard />} />
+                <Route path="membership" element={<AdminMembershipPage />} />
+              </Route>
             </Route>
+
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>

--- a/client/src/components/admin/MembershipForm.tsx
+++ b/client/src/components/admin/MembershipForm.tsx
@@ -1,0 +1,100 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { type MembershipPlan } from "@/pages/AdminMembershipPage";
+
+// The form will handle the data, but not the submission logic itself.
+export type MembershipFormData = Omit<MembershipPlan, "_id">;
+
+interface MembershipFormProps {
+  onSave: (data: MembershipFormData) => void;
+  onCancel: () => void;
+  planToEdit?: MembershipPlan | null;
+}
+
+const MembershipForm = ({ onSave, onCancel, planToEdit }: MembershipFormProps) => {
+  const [name, setName] = useState("");
+  const [price, setPrice] = useState<number | string>("");
+  const [duration, setDuration] = useState<"monthly" | "quarterly" | "yearly" | "">("");
+  const [features, setFeatures] = useState("");
+
+  useEffect(() => {
+    if (planToEdit) {
+      setName(planToEdit.name);
+      setPrice(planToEdit.price);
+      setDuration(planToEdit.duration);
+      setFeatures(planToEdit.features.join("\n"));
+    } else {
+      // Reset form for new entry
+      setName("");
+      setPrice("");
+      setDuration("");
+      setFeatures("");
+    }
+  }, [planToEdit]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData: MembershipFormData = {
+      name,
+      price: Number(price),
+      duration: duration as "monthly" | "quarterly" | "yearly",
+      features: features.split("\n").filter((f) => f.trim() !== ""),
+    };
+    onSave(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <Label htmlFor="name">Plan Name</Label>
+        <Input id="name" value={name} onChange={(e) => setName(e.target.value)} required />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <Label htmlFor="price">Price</Label>
+          <Input id="price" type="number" value={price} onChange={(e) => setPrice(e.target.value)} required />
+        </div>
+        <div>
+          <Label htmlFor="duration">Duration</Label>
+          <Select value={duration} onValueChange={(value: string) => setDuration(value as 'monthly' | 'quarterly' | 'yearly')} required>
+            <SelectTrigger id="duration">
+              <SelectValue placeholder="Select duration" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="monthly">Monthly</SelectItem>
+              <SelectItem value="quarterly">Quarterly</SelectItem>
+              <SelectItem value="yearly">Yearly</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div>
+        <Label htmlFor="features">Features (one per line)</Label>
+        <Textarea
+          id="features"
+          placeholder="- Feature 1&#x0a;- Feature 2&#x0a;- Feature 3"
+          value={features}
+          onChange={(e) => setFeatures(e.target.value)}
+        />
+      </div>
+      <div className="flex justify-end space-x-2 pt-4">
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit">Save Plan</Button>
+      </div>
+    </form>
+  );
+};
+
+export default MembershipForm;

--- a/client/src/components/layout/AdminLayout.tsx
+++ b/client/src/components/layout/AdminLayout.tsx
@@ -1,0 +1,44 @@
+import { NavLink, Outlet } from 'react-router-dom';
+
+const AdminLayout = () => {
+  return (
+    <div className="flex h-screen bg-gray-100 dark:bg-gray-900">
+      {/* Sidebar */}
+      <aside className="w-64 bg-gray-800 text-white flex flex-col">
+        <div className="p-4 text-2xl font-bold border-b border-gray-700">
+          Admin Panel
+        </div>
+        <nav className="flex-1 p-2">
+          <NavLink
+            to="/admin"
+            end // 'end' is important for the root admin path
+            className={({ isActive }) =>
+              `block py-2.5 px-4 rounded transition duration-200 hover:bg-gray-700 ${
+                isActive ? 'bg-gray-700 text-white font-semibold' : 'text-gray-300 hover:text-white'
+              }`
+            }
+          >
+            Dashboard
+          </NavLink>
+          <NavLink
+            to="/admin/membership"
+            className={({ isActive }) =>
+              `block py-2.5 px-4 rounded transition duration-200 hover:bg-gray-700 ${
+                isActive ? 'bg-gray-700 text-white font-semibold' : 'text-gray-300 hover:text-white'
+              }`
+            }
+          >
+            Membership Plans
+          </NavLink>
+        </nav>
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 p-6 sm:p-10 overflow-y-auto">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/client/src/pages/AdminDashboard.tsx
+++ b/client/src/pages/AdminDashboard.tsx
@@ -1,0 +1,12 @@
+const AdminDashboard = () => {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-gray-800 dark:text-white">Admin Dashboard</h1>
+      <p className="text-gray-600 dark:text-gray-300 mt-2">
+        Welcome to the admin panel. Use the sidebar to navigate to different sections.
+      </p>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/client/src/pages/AdminMembershipPage.tsx
+++ b/client/src/pages/AdminMembershipPage.tsx
@@ -1,0 +1,316 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { MoreHorizontal, Trash2 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator
+} from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import MembershipForm, { type MembershipFormData } from "@/components/admin/MembershipForm";
+import { useAuth } from "@/hooks/useAuth";
+import { useToast } from "@/hooks/use-toast";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Define the type for a membership plan
+export type MembershipPlan = {
+  _id: string;
+  name: string;
+  price: number;
+  duration: "monthly" | "quarterly" | "yearly";
+  features: string[];
+};
+
+// API Functions
+const fetchMemberships = async (): Promise<MembershipPlan[]> => {
+  const response = await fetch("/api/memberships");
+  if (!response.ok) {
+    throw new Error("Network response was not ok");
+  }
+  return response.json();
+};
+
+const createMembership = async (data: MembershipFormData, token: string | null) => {
+  const response = await fetch("/api/memberships", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.msg || "Failed to create membership plan");
+  }
+  return response.json();
+};
+
+const updateMembership = async ({ id, data, token }: { id: string, data: MembershipFormData, token: string | null }) => {
+  const response = await fetch(`/api/memberships/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(data),
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.msg || "Failed to update membership plan");
+  }
+  return response.json();
+};
+
+const deleteMembership = async ({ id, token }: { id: string, token: string | null }) => {
+  const response = await fetch(`/api/memberships/${id}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.msg || "Failed to delete membership plan");
+  }
+  return response.json();
+};
+
+
+const AdminMembershipPage = () => {
+  const { token } = useAuth();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
+  const [editingPlan, setEditingPlan] = useState<MembershipPlan | null>(null);
+  const [planToDelete, setPlanToDelete] = useState<MembershipPlan | null>(null);
+
+  // Queries
+  const { data: memberships, isLoading, isError, error } = useQuery<MembershipPlan[]>({
+    queryKey: ["memberships"],
+    queryFn: fetchMemberships,
+  });
+
+  // Mutations
+  const createMutation = useMutation({
+    mutationFn: (newData: MembershipFormData) => createMembership(newData, token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['memberships'] });
+      toast({ title: "Success", description: "Membership plan created." });
+      setIsFormOpen(false);
+    },
+    onError: (err: Error) => {
+      toast({ title: "Error", description: err.message || "Failed to create plan.", variant: "destructive" });
+    }
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (vars: { id: string, data: MembershipFormData }) => updateMembership({ ...vars, token }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['memberships'] });
+      toast({ title: "Success", description: "Membership plan updated." });
+      setIsFormOpen(false);
+    },
+    onError: (err: Error) => {
+      toast({ title: "Error", description: err.message || "Failed to update plan.", variant: "destructive" });
+    }
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteMembership({ id, token }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['memberships'] });
+      toast({ title: "Success", description: "Membership plan deleted." });
+      setIsAlertOpen(false);
+    },
+    onError: (err: Error) => {
+      toast({ title: "Error", description: err.message || "Failed to delete plan.", variant: "destructive" });
+    }
+  });
+
+  const handleSave = (data: MembershipFormData) => {
+    if (editingPlan) {
+      updateMutation.mutate({ id: editingPlan._id, data });
+    } else {
+      createMutation.mutate(data);
+    }
+  };
+
+  const handleOpenDeleteDialog = (plan: MembershipPlan) => {
+    setPlanToDelete(plan);
+    setIsAlertOpen(true);
+  };
+
+  const handleOpenFormDialog = (plan: MembershipPlan | null) => {
+    setEditingPlan(plan);
+    setIsFormOpen(true);
+  };
+
+  if (isLoading) {
+    return (
+      <div>
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-3xl font-bold">Manage Membership Plans</h1>
+          <Button disabled>Add New Plan</Button>
+        </div>
+        <Card>
+          <CardHeader><CardTitle>Existing Plans</CardTitle></CardHeader>
+          <CardContent>
+             <div className="space-y-4">
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+                <Skeleton className="h-8 w-full" />
+             </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return <div className="text-red-500">Error loading membership plans: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold">Manage Membership Plans</h1>
+        <Button onClick={() => handleOpenFormDialog(null)}>Add New Plan</Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Existing Plans</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Duration</TableHead>
+                <TableHead>Price</TableHead>
+                <TableHead>
+                  <span className="sr-only">Actions</span>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {memberships?.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center">No membership plans found.</TableCell>
+                </TableRow>
+              )}
+              {memberships?.map((plan) => (
+                <TableRow key={plan._id}>
+                  <TableCell className="font-medium">{plan.name}</TableCell>
+                  <TableCell className="capitalize">{plan.duration}</TableCell>
+                  <TableCell>${plan.price.toFixed(2)}</TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button aria-haspopup="true" size="icon" variant="ghost">
+                          <MoreHorizontal className="h-4 w-4" />
+                          <span className="sr-only">Toggle menu</span>
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                        <DropdownMenuItem onClick={() => handleOpenFormDialog(plan)}>
+                          Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem className="text-red-600 hover:!text-red-600" onClick={() => handleOpenDeleteDialog(plan)}>
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Add/Edit Dialog */}
+      <Dialog open={isFormOpen} onOpenChange={setIsFormOpen}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>
+              {editingPlan ? "Edit Membership Plan" : "Add New Membership Plan"}
+            </DialogTitle>
+            <DialogDescription>
+              {editingPlan
+                ? "Make changes to the plan details here."
+                : "Fill out the form to create a new membership plan."}
+            </DialogDescription>
+          </DialogHeader>
+          <MembershipForm
+            onSave={handleSave}
+            onCancel={() => setIsFormOpen(false)}
+            planToEdit={editingPlan}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. This will permanently delete the
+              <span className="font-semibold"> {planToDelete?.name} </span>
+              plan.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => planToDelete && deleteMutation.mutate(planToDelete._id)}>
+              Continue
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+};
+
+export default AdminMembershipPage;

--- a/server/controllers/membershipController.js
+++ b/server/controllers/membershipController.js
@@ -1,0 +1,105 @@
+const Membership = require('../models/Membership');
+
+// @desc    Get all membership plans
+// @route   GET /api/memberships
+// @access  Public
+const getMemberships = async (req, res) => {
+  try {
+    const memberships = await Membership.find().sort({ price: 'asc' });
+    res.json(memberships);
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+// @desc    Get single membership plan by ID
+// @route   GET /api/memberships/:id
+// @access  Public
+const getMembershipById = async (req, res) => {
+  try {
+    const membership = await Membership.findById(req.params.id);
+    if (!membership) {
+      return res.status(404).json({ msg: 'Membership plan not found' });
+    }
+    res.json(membership);
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+// @desc    Create a membership plan
+// @route   POST /api/memberships
+// @access  Private/Admin
+const createMembership = async (req, res) => {
+  const { name, price, duration, features } = req.body;
+
+  try {
+    const newMembership = new Membership({
+      name,
+      price,
+      duration,
+      features,
+    });
+
+    const savedMembership = await newMembership.save();
+    res.status(201).json(savedMembership);
+  } catch (err) {
+    console.error(err.message);
+    if (err.name === 'ValidationError') {
+        return res.status(400).json({ msg: 'Validation error', errors: err.errors });
+    }
+    if (err.code === 11000) {
+        return res.status(400).json({ msg: 'A membership plan with this name already exists.' });
+    }
+    res.status(500).send('Server Error');
+  }
+};
+
+// @desc    Update a membership plan
+// @route   PUT /api/memberships/:id
+// @access  Private/Admin
+const updateMembership = async (req, res) => {
+  try {
+    const updatedMembership = await Membership.findByIdAndUpdate(req.params.id, req.body, {
+      new: true,
+      runValidators: true,
+    });
+
+    if (!updatedMembership) {
+      return res.status(404).json({ msg: 'Membership plan not found' });
+    }
+
+    res.json(updatedMembership);
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+// @desc    Delete a membership plan
+// @route   DELETE /api/memberships/:id
+// @access  Private/Admin
+const deleteMembership = async (req, res) => {
+  try {
+    const deletedMembership = await Membership.findByIdAndDelete(req.params.id);
+
+    if (!deletedMembership) {
+      return res.status(404).json({ msg: 'Membership plan not found' });
+    }
+
+    res.json({ msg: 'Membership plan removed' });
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send('Server Error');
+  }
+};
+
+module.exports = {
+  getMemberships,
+  getMembershipById,
+  createMembership,
+  updateMembership,
+  deleteMembership,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,7 @@ app.use(express.json());
 app.get('/', (req, res) => res.send('Bharat Barbell Club API is running!'));
 app.use('/api/classes', require('./routes/classes'));
 app.use('/api/auth', require('./routes/auth'));
+app.use('/api/memberships', require('./routes/memberships'));
 
 const server = app.listen(port, () => console.log(`🚀 Server is running on port: ${port}`));
 

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -28,4 +28,19 @@ const protect = (req, res, next) => {
   }
 };
 
-module.exports = { protect };
+const authorize = (...roles) => {
+  return (req, res, next) => {
+    if (!req.user) {
+      // This should technically not be reached if 'protect' middleware is used before this
+      return res.status(401).json({ msg: 'Not authorized, user data not found' });
+    }
+    if (!roles.includes(req.user.role)) {
+      return res.status(403).json({
+        msg: `Forbidden: Your role ('${req.user.role}') does not have permission to access this resource.`,
+      });
+    }
+    next();
+  };
+};
+
+module.exports = { protect, authorize };

--- a/server/models/Membership.js
+++ b/server/models/Membership.js
@@ -1,0 +1,31 @@
+const mongoose = require('mongoose');
+
+const MembershipSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: [true, 'Please provide a membership name'],
+    trim: true,
+    unique: true,
+  },
+  price: {
+    type: Number,
+    required: [true, 'Please provide a price'],
+  },
+  duration: {
+    type: String,
+    enum: ['monthly', 'quarterly', 'yearly'],
+    required: [true, 'Please specify the duration (monthly, quarterly, or yearly)'],
+  },
+  features: {
+    type: [String],
+    default: [],
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+const Membership = mongoose.model('Membership', MembershipSchema);
+
+module.exports = Membership;

--- a/server/routes/memberships.js
+++ b/server/routes/memberships.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getMemberships,
+  getMembershipById,
+  createMembership,
+  updateMembership,
+  deleteMembership,
+} = require('../controllers/membershipController');
+const { protect, authorize } = require('../middleware/authMiddleware');
+
+// @route   GET /api/memberships
+// @desc    Get all membership plans
+// @access  Public
+router.get('/', getMemberships);
+
+// @route   GET /api/memberships/:id
+// @desc    Get a single membership plan by ID
+// @access  Public
+router.get('/:id', getMembershipById);
+
+// @route   POST /api/memberships
+// @desc    Create a membership plan
+// @access  Private (Admin only)
+router.post('/', protect, authorize('admin'), createMembership);
+
+// @route   PUT /api/memberships/:id
+// @desc    Update a membership plan
+// @access  Private (Admin only)
+router.put('/:id', protect, authorize('admin'), updateMembership);
+
+// @route   DELETE /api/memberships/:id
+// @desc    Delete a membership plan
+// @access  Private (Admin only)
+router.delete('/:id', protect, authorize('admin'), deleteMembership);
+
+module.exports = router;


### PR DESCRIPTION
This commit introduces a new, separate admin panel and a full-stack feature for managing membership plans.

Key changes:
- **Backend**:
  - Adds a new Mongoose model for `Membership`.
  - Implements a full set of CRUD API endpoints at `/api/memberships`.
  - Secures the new endpoints using a new `authorize` middleware that restricts access to admin users.
  - Improves error handling for duplicate entries in the controller.

- **Frontend**:
  - Refactors the main routing in `App.tsx` to support two distinct layouts: one for public-facing pages and a new one for the admin section.
  - Creates a new `AdminLayout` component with a dedicated sidebar for admin navigation.
  - Implements a new `AdminMembershipPage` with a complete UI for managing membership plans.
  - Uses `@tanstack/react-query` for all data fetching and mutations, including loading/error states and automatic data invalidation.
  - Implements user feedback with toasts and confirmation dialogs for destructive actions.